### PR TITLE
FixToastWhenBookingsImported

### DIFF
--- a/pages/invoice/import-innsist.vue
+++ b/pages/invoice/import-innsist.vue
@@ -847,11 +847,10 @@ async function importBookings() {
           detail: `Import process successful. ${elementsToImportNumber} bookings imported.`,
           life: 5000
         })
-        onClose()
         options.value.loading = false
-        await getList()
         showErrorsDataTable.value = false
         showDataTable.value = true
+        onClose()
       }
 
       await updateBookingsStatus(processId.value)


### PR DESCRIPTION
Se elimina el método de consultar los bookings disponibles en Innsist una vez que se realiza correctamente el proceso de importación ya que una vez que se importa se cierra la ventana de importación, por lo que no se requiere consultar nuevamente.